### PR TITLE
Wait till keyFile is loaded before connect

### DIFF
--- a/lgtv.js
+++ b/lgtv.js
@@ -563,8 +563,8 @@ function main(){
                     if (err) adapter.log.error('writeFile ERROR = ' + JSON.stringify(err));
                 });
             }
+            connect();
         });
-        connect();
     } else {
         adapter.log.error('No configure IP address');
     }


### PR DESCRIPTION
Hi,

just tried your plugin and it is great! I just had one issue with it. My TV was always asking me to accept the connection. I did some debugging and found the issue:

You are correctly writing the key to a file, but when you read the file at startup you do not wait for the file to finish reading. This leads to an issue where the connection starts before the key can be retrieved from the file. By moving the` connect() `function to the` fs.readFile` callback, you ensure that the connection starts after the file is retrieved(or not, depends on if this is the first run).
