### PR TITLE
merge 1.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ is true when TV is on and false if TV is off
 
 
 ## Changelog
+### 1.1.5 (2020-02-25)
+* (dirkhe) stable connection and subsciptions
+* (dirkhe) add Polling for TV, which not support Power Off event 
+* (dirkhe) change some states role switch to button
 
 ### 1.1.4 (2020-02-07)
 * (dirkhe) changed from pull to subscribing

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,20 @@
 {
   "common": {
     "name": "lgtv",
-    "version": "1.1.5-RC5",
+    "version": "1.1.5",
     "news": {
+      "1.1.5": {
+        "en": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button",
+        "de": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button",
+        "ru": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button",
+        "pt": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button",
+        "nl": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button",
+        "fr": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button",
+        "it": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button",
+        "es": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button",
+        "pl": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button",
+        "zh-cn": "stable connection and subsciptions\nadd Polling for TV, which not support Power Off event\nchange some states role switch to button"
+      },
       "1.1.4": {
         "en": "changed from pull to subscribing\nadd livetv to launch list",
         "de": "changed from pull to subscribing\nadd livetv to launch list",
@@ -149,7 +161,7 @@
       "type": "state",
       "common": {
         "name": "Switch TV OFF",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -185,7 +197,7 @@
       "type": "state",
       "common": {
         "name": "Volume UP",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -197,7 +209,7 @@
       "type": "state",
       "common": {
         "name": "Volume DOWN",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -245,7 +257,7 @@
       "type": "state",
       "common": {
         "name": "Channel UP",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -257,7 +269,7 @@
       "type": "state",
       "common": {
         "name": "Channel DOWN",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -269,7 +281,7 @@
       "type": "state",
       "common": {
         "name": "Media Play",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -281,7 +293,7 @@
       "type": "state",
       "common": {
         "name": "Media Pause",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -293,7 +305,7 @@
       "type": "state",
       "common": {
         "name": "Media Stop",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -305,7 +317,7 @@
       "type": "state",
       "common": {
         "name": "Media Fast Forward",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -317,7 +329,7 @@
       "type": "state",
       "common": {
         "name": "Media Rewind",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -442,7 +454,7 @@
       "type": "state",
       "common": {
         "name": "Click",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -488,7 +500,7 @@
       "type": "state",
       "common": {
         "name": "Remote key power",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -500,7 +512,7 @@
       "type": "state",
       "common": {
         "name": "Remote key red",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -512,7 +524,7 @@
       "type": "state",
       "common": {
         "name": "Remote key green",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -524,7 +536,7 @@
       "type": "state",
       "common": {
         "name": "Remote key yellow",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -536,7 +548,7 @@
       "type": "state",
       "common": {
         "name": "Remote key blue",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -548,7 +560,7 @@
       "type": "state",
       "common": {
         "name": "Remote key home",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -560,7 +572,7 @@
       "type": "state",
       "common": {
         "name": "Remote key menu",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -572,7 +584,7 @@
       "type": "state",
       "common": {
         "name": "Remote key cc",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -584,7 +596,7 @@
       "type": "state",
       "common": {
         "name": "Remote key back",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -596,7 +608,7 @@
       "type": "state",
       "common": {
         "name": "Remote key up",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -608,7 +620,7 @@
       "type": "state",
       "common": {
         "name": "Remote key down",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -620,7 +632,7 @@
       "type": "state",
       "common": {
         "name": "Remote key left",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -632,7 +644,7 @@
       "type": "state",
       "common": {
         "name": "Remote key right",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -644,7 +656,7 @@
       "type": "state",
       "common": {
         "name": "Remote key enter",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -656,7 +668,7 @@
       "type": "state",
       "common": {
         "name": "Remote key dash",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -668,7 +680,7 @@
       "type": "state",
       "common": {
         "name": "Remote key exit",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -680,7 +692,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 0",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -692,7 +704,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 1",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -704,7 +716,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 2",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -716,7 +728,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 3",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -728,7 +740,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 4",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -740,7 +752,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 5",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -752,7 +764,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 6",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -764,7 +776,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 7",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -776,7 +788,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 8",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true
@@ -788,7 +800,7 @@
       "type": "state",
       "common": {
         "name": "Remote key 9",
-        "role": "switch",
+        "role": "button",
         "type": "boolean",
         "read": false,
         "write": true

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "lgtv",
-    "version": "1.1.3",
+    "version": "1.1.5",
     "news": {
       "1.1.4": {
         "en": "changed from pull to subscribing\nadd livetv to launch list",

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "lgtv",
-    "version": "1.1.5",
+    "version": "1.1.5-RC5",
     "news": {
       "1.1.4": {
         "en": "changed from pull to subscribing\nadd livetv to launch list",

--- a/lgtv.js
+++ b/lgtv.js
@@ -11,12 +11,8 @@ let adapter;
 const LGTV = require('lgtv2');
 const wol = require('wol');
 const fs = require('fs');
-/*
-let pollTimerChannel = null;
-let pollTimerOnlineStatus = null;
-let pollTimerInput = null;
-let pollTimerGetSoundOutput = null;
-*/
+
+let hostUrl
 let isConnect = false;
 let lgtvobj, clientKey, volume, oldvolume;
 let keyfile = 'lgtvkeyfile';
@@ -345,7 +341,7 @@ function startAdapter(options){
 }
 
 function connect(cb){
-    let hostUrl = 'ws://' + adapter.config.ip + ':3000' 
+    hostUrl = 'ws://' + adapter.config.ip + ':3000' 
     lgtvobj = new LGTV({
         url:       hostUrl,
         timeout:   adapter.config.timeout,
@@ -491,7 +487,7 @@ function checkCurApp(powerOff){
         if (!notChanged){ // state was changed
             renewTimeout && clearTimeout(renewTimeout); // avoid toggeling
             if (isTVon){ // if tv is now switched on ...
-                adapter.log.debug("renew connection in one minute for stable subscriptions...")
+                adapter.log.debug("renew connection in one minute for stable subscribtions...")
                 renewTimeout = setTimeout(() => {
                     lgtvobj.disconnect();
                     setTimeout(lgtvobj.connect,500,hostUrl);

--- a/lgtv.js
+++ b/lgtv.js
@@ -415,11 +415,11 @@ function connect(cb){
                 if (!curApp){ // some TV send empty app first, if they switched on
                     setTimeout(function(){
                         if (!curApp){ // curApp is not set in meantime
-                            checkCurApp(); // so TV is off
                             if (healthIntervall){
                                 clearInterval(healthIntervall);
                                 healthIntervall = false // TV works fine,  healthIntervall is not longer nessessary
                             }
+                            checkCurApp(); // so TV is off
                         }
                     },500) 
                 } else

--- a/lgtv.js
+++ b/lgtv.js
@@ -331,7 +331,7 @@ function startAdapter(options){
         },
         unload:       (callback) => {
             renewTimeout && clearTimeout(renewTimeout);
-            lgtvobj.disconnect();
+            lgtvobj && lgtvobj.disconnect();
             isConnect= false;
             checkConnection(true);
             callback();

--- a/lgtv.js
+++ b/lgtv.js
@@ -148,6 +148,8 @@ function startAdapter(options){
                         break;
 
                     case 'states.openURL':
+                        if (!state.val)
+                            return adapter.setState('states.openURL', "", true);
                         adapter.log.debug('Sending open ' + state.val + ' command to WebOS TV: ' + adapter.config.ip);
                         sendCommand('ssap://system.launcher/open', {target: state.val}, (err, val) => {
                             if (!err) adapter.setState('states.openURL', state.val, true);
@@ -275,6 +277,8 @@ function startAdapter(options){
 
                     case 'states.youtube':
                         let uri = state.val;
+                        if (!uri)
+                            return adapter.setState('states.youtube', "", true);
                         if (!~uri.indexOf('http')){
                             uri = 'https://www.youtube.com/watch?v=' + uri;
                         }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.3",
+  "version": "1.1.5",
   "author": {
     "name": "Sebastian Schultz",
     "email": "mail@sebastian-schultz.de"


### PR DESCRIPTION
HI, ich habe mal aus einigen Switches Buttons gemacht. Ist in der objekt Ansicht dann einfacher. Wenn du dass nicht willst, können wir das aber auch wieder rückgängig machen.

Zusätzlich habe ich in den Url Felder auch ein Leerstring zugelassen, damit man es wider resetten kann.
Müssten diese Sachen nicht eigentlich generell gelöscht werden, wenn sie an den TV übergeben wurden? Das gleiche mit dem Feld launch app. Hier wird die Auswahl ja an den TV übergeben. Wenn es geklappt hat, sollte das Feld doch eigentlich wieder auf "" gesetzt werden, oder?

gruss
Dirk