### PR TITLE
Add missing external_speaker option to soundOutput state list

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -533,6 +533,7 @@
           "tv_speaker": "TV Speaker",
           "external_optical": "External Optical",
           "external_arc": "External ARC",
+          "external_speaker": "External Speaker",
           "lineout": "LineOut",
           "headphone": "Headphone",
           "tv_external_speaker": "TV + External Speaker",


### PR DESCRIPTION
## Summary

Adds the missing `external_speaker` value to the `states.soundOutput` enum in `io-package.json`.

## Problem

LG WebOS reports `external_speaker` as a valid `soundOutput` value (for example when an audio receiver is connected via optical cable plus ARC, see issue #133). Because this entry is missing from the state list, the admin UI dropdown cannot display or set this output.

## Fix

One-line addition to the soundOutput states list in `io-package.json`. Order kept consistent (grouped with the other `external_*` entries).

```diff
  "external_arc": "External ARC",
+ "external_speaker": "External Speaker",
  "lineout": "LineOut",
```

## Verification

The full set of valid soundOutput values was cross-checked against the actively maintained [homebridge-webos-tv](https://github.com/merdok/homebridge-webos-tv/blob/master/config.schema.json) project. After this change the iobroker.lgtv list matches it.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` (57 tests) passes
- [x] JSON validates

Closes #133