### PR TITLE
fix: migrate to adapter timer API and re-enable compact mode (#285)

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -146,7 +146,7 @@
     "tier": 2,
     "mode": "daemon",
     "type": "multimedia",
-    "compact": false,
+    "compact": true,
     "connectionType": "local",
     "dataSource": "poll",
     "dependencies": [

--- a/main.js
+++ b/main.js
@@ -478,10 +478,16 @@ function startAdapter(options) {
             }
         },
         unload: callback => {
-            renewTimeout && clearTimeout(renewTimeout);
-            lgtvobj && lgtvobj.disconnect();
-            isConnect = false;
-            checkConnection(true);
+            try {
+                adapter.clearTimeout(renewTimeout);
+                adapter.clearInterval(healthInterval);
+                if (lgtvobj) {
+                    lgtvobj.disconnect();
+                }
+                isConnect = false;
+            } catch {
+                // ignore errors during shutdown
+            }
             callback();
         },
         ready: () => {
@@ -609,11 +615,11 @@ function connect(cb) {
                 curApp = res.appId || '';
                 if (!curApp) {
                     // some TV send empty app first, if they switched on
-                    setTimeout(function () {
+                    adapter.setTimeout(function () {
                         if (!curApp) {
                             // curApp is not set in meantime
                             if (healthInterval && !adapter.config.healthInterval) {
-                                clearInterval(healthInterval);
+                                adapter.clearInterval(healthInterval);
                                 healthInterval = false; // TV works fine,  healthInterval is not longer nessessary
                                 adapter.log.info(
                                     'detect poweroff event, polling not longer nessesary. if you have problems, check settings',
@@ -690,12 +696,12 @@ function checkConnection(secondCheck) {
     if (secondCheck) {
         if (!isConnect) {
             adapter.setStateChanged('info.connection', false, true);
-            healthInterval && clearInterval(healthInterval);
+            adapter.clearInterval(healthInterval);
             checkCurApp(true);
         }
     } else {
         isConnect = false;
-        setTimeout(checkConnection, 10000, true); //check, if isConnect is changed in 10 sec
+        adapter.setTimeout(checkConnection, 10000, true); //check, if isConnect is changed in 10 sec
     }
 }
 
@@ -707,7 +713,7 @@ function checkCurApp(powerOff) {
     adapter.log.debug(curApp ? `cur app is ${curApp}` : 'TV is off');
 
     if (curApp == 'com.webos.app.livetv') {
-        setTimeout(() => {
+        adapter.setTimeout(() => {
             lgtvobj.subscribe('ssap://tv/getCurrentChannel', (err, res) => {
                 if (!err && res) {
                     adapter.log.debug(`tv/getCurrentChannel: ${JSON.stringify(res)}`);
@@ -737,15 +743,15 @@ function checkCurApp(powerOff) {
     adapter.setStateChanged('states.on', isTVon, true, function (err, stateID, notChanged) {
         if (!notChanged) {
             // state was changed
-            renewTimeout && clearTimeout(renewTimeout); // avoid toggeling
+            adapter.clearTimeout(renewTimeout); // avoid toggeling
             if (isTVon) {
                 // if tv is now switched on ...
                 adapter.log.debug('renew connection in one minute for stable subscriptions...');
-                renewTimeout = setTimeout(() => {
+                renewTimeout = adapter.setTimeout(() => {
                     lgtvobj.disconnect();
-                    setTimeout(lgtvobj.connect, 500, hostUrl);
+                    adapter.setTimeout(lgtvobj.connect, 500, hostUrl);
                     if (healthInterval !== false) {
-                        healthInterval = setInterval(
+                        healthInterval = adapter.setInterval(
                             sendCommand,
                             adapter.config.healthInterval || 60000,
                             'ssap://com.webos.service.tv.time/getCurrentTime',
@@ -803,11 +809,11 @@ function bypassCertificateValidation() {
 function SetVolume(val) {
     if (val >= volume + 5) {
         let vol = oldvolume;
-        const interval = setInterval(() => {
+        const interval = adapter.setInterval(() => {
             vol = vol + 2;
             if (vol >= val) {
                 vol = val;
-                clearInterval(interval);
+                adapter.clearInterval(interval);
             }
             sendCommand('ssap://audio/setVolume', { volume: vol }, (err, _resp) => {
                 if (!err) {


### PR DESCRIPTION
Addresses all three checkboxes from #285:

- [x] Several timers are not recorded and cleaned at unload
- [x] adapter.setTimeout should be used
- [x] compact mode should be reenabled after sanitizing timer handling

## Changes

**main.js** — every native timer call is replaced by its `adapter.*` equivalent so all timers participate in the adapter lifecycle and are automatically cleared on unload:

| Location | Before | After |
| --- | --- | --- |
| connect / empty-app guard | `setTimeout(...)` | `adapter.setTimeout(...)` |
| connect / health-stop branch | `clearInterval(healthInterval)` | `adapter.clearInterval(healthInterval)` |
| checkConnection / second-check branch | `clearInterval(healthInterval)` | `adapter.clearInterval(healthInterval)` |
| checkConnection / re-check delay | `setTimeout(checkConnection, 10000, true)` | `adapter.setTimeout(...)` |
| checkCurApp / channel subscribe delay | `setTimeout(...)` | `adapter.setTimeout(...)` |
| checkCurApp / on-toggle cancel | `clearTimeout(renewTimeout)` | `adapter.clearTimeout(renewTimeout)` |
| checkCurApp / renew connection | `setTimeout(...)` / `setInterval(...)` | `adapter.setTimeout(...)` / `adapter.setInterval(...)` |
| checkCurApp / late reconnect | `setTimeout(lgtvobj.connect, 500, hostUrl)` | `adapter.setTimeout(...)` |
| SetVolume / fade interval | `setInterval(...)` / `clearInterval(...)` | `adapter.setInterval(...)` / `adapter.clearInterval(...)` |

**unload handler** — was previously starting a `checkConnection(true)` re-entry which itself queued a fresh `setTimeout` after shutdown had begun. Replaced by an explicit, synchronous teardown:

```js
unload: callback => {
    try {
        adapter.clearTimeout(renewTimeout);
        adapter.clearInterval(healthInterval);
        if (lgtvobj) {
            lgtvobj.disconnect();
        }
        isConnect = false;
    } catch {
        // ignore errors during shutdown
    }
    callback();
},
```

`info.connection = false` is no longer set explicitly during unload — js-controller does this automatically when the adapter terminates, so the previous async `setStateChanged` call before `callback()` was both redundant and a small race risk.

**io-package.json** — `compact: false` → `compact: true`. The previous changelog note ("Compact mode has been disabled due to outdated timer handling") becomes obsolete with this PR.

## Verification

- `npm run lint` — clean
- `npm test` — 57 passing
- `npm run test:integration` — adapter starts, runs without crash on missing IP, terminates cleanly via `TERMINATE_YOURSELF` (no UNCAUGHT_EXCEPTION, no SIGKILL)

## Notes

- No dependency or behavior changes outside the timer API migration and the unload simplification.
- Compact mode was already wired up at the bottom of `main.js` (`module.exports = startAdapter`); only the io-package.json flag needed to be flipped.

🤖 Co-authored with [Claude](https://claude.ai/) (Opus 4.7)