### PR TITLE
feat: add picture settings — pictureMode, brightness, backlight, contrast, color, colorTemperature, energySaving, eyeComfortMode, justScan (#113, #99)

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -892,6 +892,189 @@
         "write": true
       },
       "native": {}
+    },
+    {
+      "_id": "states.picture",
+      "type": "channel",
+      "common": {
+        "name": "Picture settings"
+      },
+      "native": {}
+    },
+    {
+      "_id": "states.picture.pictureMode",
+      "type": "state",
+      "common": {
+        "name": "Picture mode",
+        "desc": "Union of picture-mode IDs across LG OLED generations C8 (2018) through G5 (2025). Only a subset is active per TV model and content type (SDR / HDR / Dolby Vision); writing an unsupported value is silently ignored by the TV.",
+        "role": "state",
+        "type": "string",
+        "read": true,
+        "write": true,
+        "states": {
+          "cinema": "Cinema",
+          "dolbyHdrCinema": "Dolby HDR Cinema",
+          "dolbyHdrCinemaBright": "Dolby HDR Cinema Bright",
+          "dolbyHdrDarkAmazon": "Dolby HDR Dark Amazon",
+          "dolbyHdrGame": "Dolby HDR Game",
+          "dolbyHdrPersonalized": "Dolby HDR Personalized",
+          "dolbyHdrStandard": "Dolby HDR Standard",
+          "dolbyHdrVivid": "Dolby HDR Vivid",
+          "dolbyStandard": "Dolby Standard",
+          "eco": "Eco",
+          "expert1": "Expert 1",
+          "expert2": "Expert 2",
+          "filmMaker": "Filmmaker",
+          "game": "Game",
+          "hdrCinema": "HDR Cinema",
+          "hdrCinemaBright": "HDR Cinema Bright",
+          "hdrEco": "HDR Eco",
+          "hdrEffect": "HDR Effect",
+          "hdrExternal": "HDR External",
+          "hdrFilmMaker": "HDR Filmmaker",
+          "hdrGame": "HDR Game",
+          "hdrPersonalized": "HDR Personalized",
+          "hdrStandard": "HDR Standard",
+          "hdrTechnicolor": "HDR Technicolor",
+          "hdrVivid": "HDR Vivid",
+          "normal": "Normal",
+          "personalized": "Personalized",
+          "photo": "Photo",
+          "sports": "Sports",
+          "technicolor": "Technicolor",
+          "technicolorHdrCinema": "Technicolor HDR Cinema",
+          "technicolorHdrCinemaBright": "Technicolor HDR Cinema Bright",
+          "technicolorHdrGame": "Technicolor HDR Game",
+          "technicolorHdrStandard": "Technicolor HDR Standard",
+          "technicolorHdrTechnicolor": "Technicolor HDR Technicolor",
+          "technicolorHdrVivid": "Technicolor HDR Vivid",
+          "vivid": "Vivid"
+        }
+      },
+      "native": {}
+    },
+    {
+      "_id": "states.picture.brightness",
+      "type": "state",
+      "common": {
+        "name": "Brightness",
+        "role": "level.brightness",
+        "type": "number",
+        "min": 0,
+        "max": 100,
+        "read": true,
+        "write": true
+      },
+      "native": {}
+    },
+    {
+      "_id": "states.picture.backlight",
+      "type": "state",
+      "common": {
+        "name": "Backlight",
+        "role": "level.dimmer",
+        "type": "number",
+        "min": 0,
+        "max": 100,
+        "read": true,
+        "write": true
+      },
+      "native": {}
+    },
+    {
+      "_id": "states.picture.contrast",
+      "type": "state",
+      "common": {
+        "name": "Contrast",
+        "role": "level",
+        "type": "number",
+        "min": 0,
+        "max": 100,
+        "read": true,
+        "write": true
+      },
+      "native": {}
+    },
+    {
+      "_id": "states.picture.color",
+      "type": "state",
+      "common": {
+        "name": "Color saturation",
+        "role": "level.saturation",
+        "type": "number",
+        "min": 0,
+        "max": 100,
+        "read": true,
+        "write": true
+      },
+      "native": {}
+    },
+    {
+      "_id": "states.picture.colorTemperature",
+      "type": "state",
+      "common": {
+        "name": "Color temperature",
+        "role": "level",
+        "type": "number",
+        "min": -50,
+        "max": 50,
+        "read": true,
+        "write": true
+      },
+      "native": {}
+    },
+    {
+      "_id": "states.picture.justScan",
+      "type": "state",
+      "common": {
+        "name": "Just Scan (overscan)",
+        "role": "state",
+        "type": "string",
+        "read": true,
+        "write": true,
+        "states": {
+          "auto": "Auto",
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "native": {}
+    },
+    {
+      "_id": "states.picture.energySaving",
+      "type": "state",
+      "common": {
+        "name": "Energy saving mode",
+        "role": "state",
+        "type": "string",
+        "read": true,
+        "write": true,
+        "states": {
+          "auto": "Auto",
+          "off": "Off",
+          "min": "Min",
+          "med": "Medium",
+          "max": "Max",
+          "screen_off": "Screen off"
+        }
+      },
+      "native": {}
+    },
+    {
+      "_id": "states.picture.eyeComfortMode",
+      "type": "state",
+      "common": {
+        "name": "Eye Comfort / Reduce Blue Light",
+        "role": "switch",
+        "type": "string",
+        "read": true,
+        "write": true,
+        "states": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "native": {}
     }
   ]
 }

--- a/main.js
+++ b/main.js
@@ -15,6 +15,39 @@ let renewTimeout = null;
 let healthInterval = null;
 let curApp = '';
 
+// Picture settings — write goes through createAlert with the alert immediately
+// closed (the TV applies the luna setting via the onclose handler). Read goes
+// through ssap://settings/getSystemSettings, one subscription per key so a
+// single unsupported property does not silently kill the whole subscription.
+const PICTURE_KEYS = new Set([
+    'pictureMode',
+    'brightness',
+    'backlight',
+    'contrast',
+    'color',
+    'colorTemperature',
+    'energySaving',
+    'eyeComfortMode',
+    'justScan',
+]);
+const PICTURE_NUMERIC_KEYS = new Set(['brightness', 'backlight', 'contrast', 'color', 'colorTemperature']);
+// Picture writes go through the generic "picture" category; justScan is the
+// one exception — it accepts writes via the dedicated "aspectRatio" category.
+// All reads go through "picture"; webOS authorisation blocks reads of
+// pictureMode/colorTemperature/eyeComfortMode/justScan from there as well, so
+// those four properties end up effectively write-only on the public API.
+function setCategoryFor(key) {
+    return key === 'justScan' ? 'aspectRatio' : 'picture';
+}
+
+function coercePictureValue(key, raw) {
+    if (PICTURE_NUMERIC_KEYS.has(key)) {
+        const n = typeof raw === 'number' ? raw : Number(raw);
+        return Number.isFinite(n) ? n : null;
+    }
+    return typeof raw === 'string' ? raw : String(raw);
+}
+
 function startAdapter(options) {
     options = options || {};
     Object.assign(options, {
@@ -30,6 +63,13 @@ function startAdapter(options) {
                     dy = parseInt(vals[1]);
                 }
                 adapter.log.debug(`State change "${id}" - VALUE: ${state.val}`);
+                if (id.startsWith('states.picture.')) {
+                    const key = id.substring('states.picture.'.length);
+                    if (PICTURE_KEYS.has(key) && state.val !== null && state.val !== undefined) {
+                        setPictureSetting(key, state.val);
+                    }
+                    return;
+                }
                 switch (id) {
                     case 'states.popup':
                         adapter.log.debug(`Sending popup message "${state.val}" to WebOS TV: ${adapter.config.ip}`);
@@ -639,6 +679,31 @@ function connect(cb) {
                 adapter.log.debug(`ERROR on getSoundOutput: ${err}`);
             }
         });
+        // Subscribe to each picture setting individually — bundling keys into a
+        // single request silently drops the whole subscription on TVs that do not
+        // support every key (varies by webOS version and model). The TV pushes
+        // some properties only on change, so we additionally fetch the initial
+        // values via request for every key.
+        PICTURE_KEYS.forEach(key => {
+            const cat = 'picture';
+            const handler = (err, res) => {
+                if (err) {
+                    adapter.log.debug(`getSystemSettings(${cat}.${key}) error: ${err}`);
+                    return;
+                }
+                if (res && res.settings && res.settings[key] !== undefined && res.settings[key] !== null) {
+                    const value = coercePictureValue(key, res.settings[key]);
+                    if (value !== null) {
+                        adapter.log.debug(`getSystemSettings ${cat}.${key}: ${value}`);
+                        adapter.setState(`states.picture.${key}`, value, true);
+                    }
+                } else {
+                    adapter.log.debug(`getSystemSettings ${cat}.${key} no value: ${JSON.stringify(res).slice(0, 200)}`);
+                }
+            };
+            lgtvobj.subscribe('ssap://settings/getSystemSettings', { category: cat, keys: [key] }, handler);
+            lgtvobj.request('ssap://settings/getSystemSettings', { category: cat, keys: [key] }, handler);
+        });
         sendCommand('ssap://api/getServiceList', null, (err, val) => {
             if (!err) {
                 adapter.log.debug(`Service list: ${JSON.stringify(val)}`);
@@ -686,6 +751,40 @@ const inputList = arr => {
     });
     return obj;
 };
+
+// Writes a single picture setting via the createAlert + onClick(luna) bridge.
+// The direct ssap setSystemSettings path is not exposed on the public web
+// socket interface, so we hand the actual luna URI to a system alert which the
+// TV executes via its onclose/onfail handlers. The alert is closed
+// programmatically right after creation, keeping the popup invisible.
+function setPictureSetting(key, value) {
+    const params = { category: setCategoryFor(key), settings: { [key]: value } };
+    const lunaUri = 'luna://com.webos.settingsservice/setSystemSettings';
+    sendCommand(
+        'ssap://system.notifications/createAlert',
+        {
+            title: ' ',
+            message: ' ',
+            modal: true,
+            type: 'confirm',
+            isSysReq: true,
+            buttons: [{ label: 'OK', focus: true, buttonType: 'ok', onClick: lunaUri, params }],
+            onclose: { uri: lunaUri, params },
+            onfail: { uri: lunaUri, params },
+        },
+        (err, val) => {
+            if (err) {
+                adapter.log.warn(`set picture.${key}=${value} failed: ${err}`);
+                return;
+            }
+            adapter.log.debug(`set picture.${key}=${value}: ${JSON.stringify(val)}`);
+            adapter.setState(`states.picture.${key}`, value, true);
+            if (val && val.alertId) {
+                sendCommand('ssap://system.notifications/closeAlert', { alertId: val.alertId }, () => {});
+            }
+        },
+    );
+}
 function checkConnection(secondCheck) {
     if (secondCheck) {
         if (!isConnect) {


### PR DESCRIPTION
Adds 9 new states under `states.picture.*` to read and write LG webOS picture settings, addressing #113 ("more options like picture mode", open since 2021) and the picture-settings request in #99.

## States added

| State | Type | Notes |
| --- | --- | --- |
| `states.picture` (channel) | — | Group |
| `states.picture.pictureMode` | string | 37 known mode IDs as enum hint, **see note below** |
| `states.picture.brightness` | number 0-100 | Range constant across all documented webOS versions |
| `states.picture.backlight` | number 0-100 | Range constant |
| `states.picture.contrast` | number 0-100 | Range constant |
| `states.picture.color` | number 0-100 | Saturation, range constant |
| `states.picture.colorTemperature` | number -50…50 | Range constant |
| `states.picture.justScan` | string | `auto / on / off` |
| `states.picture.energySaving` | string | `auto / off / min / med / max / screen_off` (the last only on older models) |
| `states.picture.eyeComfortMode` | string | `on / off` |

## ⚠️ Note on pictureMode (and other enums)

The `pictureMode` `common.states` list is the **union of mode IDs across the LG OLED generations C8 (2018) through G5 (2025)** — 37 values total. **It is not a per-device list**, and which subset actually works depends on:

1. **The TV model / webOS version** — older models support different picture modes than newer ones (e.g. `technicolor*` only exists on C8/C9, `personalized` only on C2/G3-G5).
2. **The active content type** — when the TV is showing Dolby Vision content, only the `dolbyHdr*` modes are honoured visibly; SDR/HDR content honours the corresponding non-DV modes.

Writing a mode value the TV does not currently accept is silently ignored. Because `pictureMode` is `type: string`, users can also set arbitrary mode IDs that may exist on devices not covered by the list above.

`colorTemperature`, `aspectRatio`, `eyeComfortMode` and `justScan` show similar device-specific behaviour but on smaller scales.

## Set path — alert + luna bridge

The direct `ssap://settings/setSystemSettings` endpoint is not exposed on the public WebSocket interface. Setting goes through a system alert (`createAlert`) with `isSysReq: true` whose `onClick`/`onclose`/`onfail` handlers carry the actual `luna://com.webos.settingsservice/setSystemSettings` URI and params; the alert is closed programmatically right after creation, keeping the popup invisible. `justScan` writes are routed to the `aspectRatio` category, everything else to `picture`.

This pattern is also used by `aiopylgtv`, `bscpylgtv` (`set_settings` method) and `homebridge-lgwebos-tv`.

## Read path — per-key subscribe + initial request

Each key has its own `subscribe` and `request` on `ssap://settings/getSystemSettings` in the `picture` category. Bundling keys into a single subscribe silently drops the whole subscription on TVs that do not support every requested key, hence the per-key approach.

The TV pushes value changes for the four numeric settings and `energySaving` on most models. `pictureMode`, `colorTemperature`, `eyeComfortMode` and `justScan` are auth-blocked for read on the public API across all bscpylgtv-documented webOS versions (TV responds with `"Some keys are not allowed for the request"`), so the adapter state for those four reflects the last user input rather than TV-side changes via the remote control. This is a webOS-side limitation — both `aiopylgtv` and `bscpylgtv` ship without read helpers for these properties for the same reason.

## Verified value lists / ranges

Every enum and numeric range was cross-referenced against bscpylgtv `available_settings_*.md` for **C8 (2018), C9 (2019), CX (2020), C1 (2021), C2 (2022), G3 (2023), G4 (2024), G5 (2025)**. Defensive design lets users on older or future models set arbitrary string values too — `type: string` does not validate against `common.states`.

## aspectRatio explored, dropped from this PR

`aspectRatio` was implemented and tested through several approaches (Luna with `current_app: true`, `setAll: true`, explicit `dimension: { input, _3dStatus }`) but the test TV silently ignored every variant. `aiopylgtv` and `bscpylgtv` ship without aspectRatio helpers for the same reason. Keeping it out of this PR rather than shipping a non-functional dropdown; can return as a follow-up if a working approach surfaces on other models.

## Verification

- `npm run lint` — clean
- `npm test` — 57 passing
- `npm run test:integration` — adapter starts and terminates cleanly
- **Live-tested** on OLED B19 (2021, webOS 6.5.3, firmware v3.53.45):
  - Set path verified for all 9 states
  - Numeric reads + `energySaving` live-pushed by the TV on subscribe
  - `pictureMode` set with content-dependent mapping verified (DV content honours `dolbyHdr*` IDs)

🤖 Co-authored with [Claude](https://claude.ai/) (Opus 4.7)