### PR TITLE
Watchdog for stuck lgtv2 reconnect cycles

### DIFF
--- a/main.js
+++ b/main.js
@@ -48,6 +48,18 @@ function coercePictureValue(key, raw) {
     return typeof raw === 'string' ? raw : String(raw);
 }
 
+// Reconnect watchdog: the underlying lgtv2 library relies on the `websocket@1`
+// package for retries. If that socket gets stuck during the connect handshake
+// (TCP open, no upgrade response, no `connectFailed` event), the library never
+// schedules another retry and the adapter stays "offline" until the user
+// restarts it. The watchdog observes how long ago the library last emitted a
+// `connecting` event and forces a fresh LGTV instance once the gap exceeds
+// the threshold while we're still disconnected.
+let lastConnectingAt = 0;
+let watchdogTimer = null;
+const WATCHDOG_CHECK_MS = 30000;
+const WATCHDOG_STUCK_MS = 60000;
+
 function startAdapter(options) {
     options = options || {};
     Object.assign(options, {
@@ -521,6 +533,10 @@ function startAdapter(options) {
             try {
                 adapter.clearTimeout(renewTimeout);
                 adapter.clearInterval(healthInterval);
+                if (watchdogTimer) {
+                    adapter.clearInterval(watchdogTimer);
+                    watchdogTimer = null;
+                }
                 if (lgtvobj) {
                     lgtvobj.disconnect();
                 }
@@ -565,6 +581,7 @@ function connect(cb) {
         },
     });
     lgtvobj.on('connecting', host => {
+        lastConnectingAt = Date.now();
         adapter.log.debug(`Connecting to WebOS TV: ${host}`);
         checkConnection();
     });
@@ -740,6 +757,11 @@ function connect(cb) {
         });
         cb && cb();
     });
+
+    lastConnectingAt = Date.now();
+    if (!watchdogTimer) {
+        watchdogTimer = adapter.setInterval(checkReconnectWatchdog, WATCHDOG_CHECK_MS);
+    }
 }
 
 const launchList = arr => {
@@ -802,6 +824,27 @@ function checkConnection(secondCheck) {
         isConnect = false;
         adapter.setTimeout(checkConnection, 10000, true); //check, if isConnect is changed in 10 sec
     }
+}
+
+function checkReconnectWatchdog() {
+    if (isConnect) {
+        return;
+    }
+    const idleMs = Date.now() - lastConnectingAt;
+    if (idleMs <= WATCHDOG_STUCK_MS) {
+        return;
+    }
+    adapter.log.warn(
+        `[WATCHDOG] No reconnect attempt for ${Math.round(idleMs / 1000)}s while disconnected — recreating LGTV instance`,
+    );
+    try {
+        lgtvobj && lgtvobj.disconnect();
+    } catch (err) {
+        adapter.log.debug(`[WATCHDOG] disconnect failed: ${err}`);
+    }
+    // Suppress retrigger until the new instance has had a chance to settle.
+    lastConnectingAt = Date.now();
+    adapter.setTimeout(connect, 1000);
 }
 
 function checkCurApp(powerOff) {


### PR DESCRIPTION
## Summary

Long-standing intermittent issue: the adapter shows the TV as `info.connection = false` even though the TV is online and reachable on the network. A manual `iobroker restart` always fixes it. This PR addresses the underlying cause without touching the abandoned `lgtv2` library.

## Root cause

The bundled `lgtv2` library relies on `websocket@1.x` for retry logic. Both reconnect paths in `node_modules/lgtv2/index.js` (the `connectFailed` handler and the `connection.close` handler) schedule the next attempt via:

```js
setTimeout(function () {
    if (autoReconnect) {
        that.connect(config.url);
    }
}, config.reconnect);
```

When the underlying `WebSocketClient.connect()` call gets stuck during the upgrade handshake — TCP open, TLS handshake started, no `connectFailed` and no `connect` event — neither path fires again. The library is then silently inactive. From the adapter's point of view there are simply no more `connecting` / `close` / `error` events; `info.connection` stays `false` until the user restarts.

In the field this is observable in the log as a normal 8 s reconnect cycle (`Connecting to WebOS TV` → `TV is off`) that suddenly stops without any error message:

```
17:13:07  debug  Connecting to WebOS TV: wss://10.47.4.5:3001
17:13:09  debug  TV is off
17:13:17  debug  TV is off          ← last heartbeat from the previous cycle's 10 s timer
[silence — 25+ minutes, until the user restarts]
```

The TV was online the entire time (confirmed via UniFi client list).

## Fix

A small watchdog inside the adapter, library-agnostic:

- Records `Date.now()` whenever `lgtvobj` emits `connecting`.
- Runs every 30 s while the adapter is up.
- Triggers when `isConnect === false` **and** no `connecting` event has been observed for more than 60 s (= 12 missed retries past the configured 5 s reconnect interval — safe sign the library is wedged).
- Best-effort `lgtvobj.disconnect()` and re-runs the existing `connect()` function. That constructs a fresh `LGTV` instance whose constructor schedules its own `connect(url)` via the existing `setTimeout(0)` hook — full self-recovery, no user action.

In normal operation (TV power-cycling, brief network blips) the library handles reconnects within seconds and the watchdog never fires. It only kicks in on the silent-stuck case described above.

The watchdog uses `adapter.setInterval` / `adapter.setTimeout` so its handles are tracked by js-controller and cleaned up automatically on shutdown. The existing native `setTimeout`/`setInterval` calls in `checkConnection` / `checkCurApp` are intentionally untouched — that migration belongs to #285 / PR #413.

## Test plan

- [x] `npm run lint` clean
- [x] Live-deployed on two LG OLED instances; in normal operation the watchdog stays silent (TV reachable → `WebOS TV Connected` within 1 s, no warnings).
- [x] Code path verified by reading `lgtv2`'s reconnect logic (only 319 LOC) and matching it against the captured log of a real stuck-state session.

## Note on the stuck-state itself

The bug is intermittent and not reproducible on demand — sometimes weeks pass between occurrences. There is no test-plan item that can prove "stuck-state recovered" without waiting for the next real-world hit. When the next occurrence happens, the warning `[WATCHDOG] No reconnect attempt for Xs while disconnected — recreating LGTV instance` will appear in the log followed by an immediate reconnect, which is the proof and the recovery in one step.

Addresses the recurring intermittent "TV stays offline" reports.