### PR TITLE
Silence health-check poll success log

### DIFF
--- a/main.js
+++ b/main.js
@@ -751,8 +751,8 @@ function checkCurApp(powerOff) {
                             'ssap://com.webos.service.tv.time/getCurrentTime',
                             null,
                             (err, _val) => {
-                                adapter.log.debug(`check TV connection: ${err || 'ok'}`);
                                 if (err) {
+                                    adapter.log.debug(`check TV connection failed: ${err}`);
                                     checkCurApp(true);
                                 }
                             },


### PR DESCRIPTION
## Summary

The `healthInterval` polls the TV every 60 s by default (configurable down to seconds via `adapter.config.healthInterval`) and currently emits one debug line per poll, even when the poll succeeds:

```js
adapter.log.debug(`check TV connection: ${err || 'ok'}`);
```

A polling success carries no diagnostic value — `info.connection` already exposes the live state, and a real disconnect surfaces through the existing `TV is off` path. With the default 60 s interval that is **1440 useless `check TV connection: ok` debug entries per day per instance**; with shorter intervals (the option allows down to 1 s) it scales linearly into clear log spam.

## What changes

The success branch is silenced; the failure path keeps the log (kept at debug — repeated polls during a TV-off period are expected and would otherwise dominate the log) and continues to call `checkCurApp(true)`.

```diff
                             (err, _val) => {
-                                adapter.log.debug(`check TV connection: ${err || 'ok'}`);
                                 if (err) {
+                                    adapter.log.debug(`check TV connection failed: ${err}`);
                                     checkCurApp(true);
                                 }
                             },
```

## Test plan

- [x] `npm run lint` clean
- [x] Live-deployed: in normal operation the line is gone, the `if (err)` branch still triggers `checkCurApp(true)` (verified by reading the surrounding `TV is off` flow).