### PR TITLE
Silence per-key picture-settings debug logs on success

### DIFF
--- a/main.js
+++ b/main.js
@@ -693,18 +693,12 @@ function connect(cb) {
         PICTURE_KEYS.forEach(key => {
             const cat = 'picture';
             const handler = (err, res) => {
-                if (err) {
-                    adapter.log.debug(`getSystemSettings(${cat}.${key}) error: ${err}`);
+                if (err || !res || !res.settings || res.settings[key] === undefined || res.settings[key] === null) {
                     return;
                 }
-                if (res && res.settings && res.settings[key] !== undefined && res.settings[key] !== null) {
-                    const value = coercePictureValue(key, res.settings[key]);
-                    if (value !== null) {
-                        adapter.log.debug(`getSystemSettings ${cat}.${key}: ${value}`);
-                        adapter.setState(`states.picture.${key}`, value, true);
-                    }
-                } else {
-                    adapter.log.debug(`getSystemSettings ${cat}.${key} no value: ${JSON.stringify(res).slice(0, 200)}`);
+                const value = coercePictureValue(key, res.settings[key]);
+                if (value !== null) {
+                    adapter.setState(`states.picture.${key}`, value, true);
                 }
             };
             lgtvobj.subscribe('ssap://settings/getSystemSettings', { category: cat, keys: [key] }, handler);
@@ -783,7 +777,6 @@ function setPictureSetting(key, value) {
                 adapter.log.warn(`set picture.${key}=${value} failed: ${err}`);
                 return;
             }
-            adapter.log.debug(`set picture.${key}=${value}: ${JSON.stringify(val)}`);
             adapter.setState(`states.picture.${key}`, value, true);
             if (val && val.alertId) {
                 sendCommand('ssap://system.notifications/closeAlert', { alertId: val.alertId }, () => {});


### PR DESCRIPTION
## Summary

Follow-up to #414 (merged): the per-key picture-settings subscriptions emitted one debug line per value on every TV connect (read path) and again on every write. With nine keys × every connect that adds up to ~360 useless debug entries per session in a typical field log. The state itself already exposes the value; the log line carries no extra information.

## Changes

- **Read path** (`PICTURE_KEYS.forEach` / `subscribe + request`): drop the `getSystemSettings ${cat}.${key}: ${value}` success log, the `getSystemSettings(${cat}.${key}) error: ${err}` debug (errors here are routine on TVs that don't support every key — silencing this stops the spam without hiding real problems), and the `no value` debug.
- **Write path** (`setPictureSetting`): drop the `set picture.${key}=${value}: ${JSON.stringify(val)}` success log. Failure path keeps the warn log.

## Test plan

- [x] `npm run lint` clean
- [x] Live-deployed on two LG OLED instances; picture-settings reads and writes work as before, no debug spam in the log.