### PR TITLE
fix(watchdog): gate recreate behind TCP reachability probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ is true when TV is on and false if TV is off
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (krobipd) Reconnect watchdog no longer warns and recreates the LGTV instance while the TV is simply switched off. A short TCP reachability probe gates the recreate so the warning only fires when the TV is actually online but the WebSocket handshake is stuck.
+
 ### 2.7.1 (2026-05-10)
 - (krobipd) Handling of online state has been improved.
 - (krobipd) Support for picture settings has been added.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,8 +10,8 @@ export default [
         ignores: [
             '.dev-server/',
             '.vscode/',
-            '*.test.js', 
-            'test/**/*.js', 
+            '**/*.test.js',
+            'test/**/*.js',
             '*.config.mjs', 
             'build', 
             'admin/build', 

--- a/lib/probe.js
+++ b/lib/probe.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const net = require('node:net');
+
+/**
+ * Best-effort TCP reachability probe.
+ *
+ * Resolves `true` if a TCP connection to `host:port` can be established
+ * within `timeoutMs`, `false` on any error or timeout. Never rejects —
+ * callers can treat a `false` result as "unreachable".
+ *
+ * @param {string} host hostname or IP address; empty string resolves false immediately
+ * @param {number} port TCP port to connect to
+ * @param {number} timeoutMs maximum time to wait for the TCP handshake before resolving false
+ * @returns {Promise<boolean>} true when the handshake completed, false on timeout or error
+ */
+function probeTcpReachable(host, port, timeoutMs) {
+    return new Promise(resolve => {
+        if (!host) {
+            resolve(false);
+            return;
+        }
+        const socket = new net.Socket();
+        let settled = false;
+        const finish = result => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            try {
+                socket.destroy();
+            } catch {
+                /* ignore */
+            }
+            resolve(result);
+        };
+        socket.setTimeout(timeoutMs);
+        socket.once('connect', () => finish(true));
+        socket.once('timeout', () => finish(false));
+        socket.once('error', () => finish(false));
+        try {
+            socket.connect(port, host);
+        } catch {
+            finish(false);
+        }
+    });
+}
+
+module.exports = { probeTcpReachable };

--- a/lib/probe.test.js
+++ b/lib/probe.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { expect } = require('chai');
+const net = require('node:net');
+const { probeTcpReachable } = require('./probe');
+
+function startListener() {
+    return new Promise((resolve, reject) => {
+        const server = net.createServer(socket => socket.end());
+        server.unref();
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => resolve(server));
+    });
+}
+
+describe('lib/probe — probeTcpReachable', () => {
+    it('resolves true when the port accepts the connection', async () => {
+        const server = await startListener();
+        try {
+            const port = server.address().port;
+            const reachable = await probeTcpReachable('127.0.0.1', port, 1000);
+            expect(reachable).to.equal(true);
+        } finally {
+            server.close();
+        }
+    });
+
+    it('resolves false when nothing listens on the port', async () => {
+        // Pick an ephemeral port we know is free by opening + closing a server.
+        const tmp = await startListener();
+        const port = tmp.address().port;
+        await new Promise(r => tmp.close(r));
+        const reachable = await probeTcpReachable('127.0.0.1', port, 1000);
+        expect(reachable).to.equal(false);
+    });
+
+    it('resolves false within the timeout when the host swallows the SYN', async () => {
+        // 192.0.2.0/24 is TEST-NET-1 (RFC 5737) — guaranteed unroutable.
+        const start = Date.now();
+        const reachable = await probeTcpReachable('192.0.2.1', 3001, 300);
+        const elapsed = Date.now() - start;
+        expect(reachable).to.equal(false);
+        expect(elapsed).to.be.lessThan(1500);
+    });
+
+    it('resolves false for an empty host without touching the network', async () => {
+        const reachable = await probeTcpReachable('', 3001, 1000);
+        expect(reachable).to.equal(false);
+    });
+});

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const LGTV = require('lgtv2');
 const wol = require('wol');
 const fs = require('node:fs');
 const path = require('node:path');
+const { probeTcpReachable } = require('./lib/probe');
 
 let hostUrl;
 let isConnect = false;
@@ -94,11 +95,17 @@ function coercePictureValue(key, raw) {
 // schedules another retry and the adapter stays "offline" until the user
 // restarts it. The watchdog observes how long ago the library last emitted a
 // `connecting` event and forces a fresh LGTV instance once the gap exceeds
-// the threshold while we're still disconnected.
+// the threshold while we're still disconnected. To avoid noisy warnings while
+// the TV is simply powered off, the watchdog gates the recreate behind a quick
+// TCP probe of the WebSocket port — the recreate (and warning) only fire when
+// the TV is actually reachable on the network.
 let lastConnectingAt = 0;
 let watchdogTimer = null;
+let watchdogProbeInFlight = false;
 const WATCHDOG_CHECK_MS = 30000;
 const WATCHDOG_STUCK_MS = 60000;
+const WATCHDOG_PROBE_PORT = 3001;
+const WATCHDOG_PROBE_TIMEOUT_MS = 2000;
 
 function startAdapter(options) {
     options = options || {};
@@ -883,24 +890,45 @@ function checkConnection(secondCheck) {
 }
 
 function checkReconnectWatchdog() {
-    if (isConnect) {
+    if (isConnect || watchdogProbeInFlight) {
         return;
     }
     const idleMs = Date.now() - lastConnectingAt;
     if (idleMs <= WATCHDOG_STUCK_MS) {
         return;
     }
-    adapter.log.warn(
-        `[WATCHDOG] No reconnect attempt for ${Math.round(idleMs / 1000)}s while disconnected — recreating LGTV instance`,
-    );
-    try {
-        lgtvobj && lgtvobj.disconnect();
-    } catch (err) {
-        adapter.log.debug(`[WATCHDOG] disconnect failed: ${err}`);
-    }
-    // Suppress retrigger until the new instance has had a chance to settle.
-    lastConnectingAt = Date.now();
-    adapter.setTimeout(connect, 1000);
+    watchdogProbeInFlight = true;
+    probeTcpReachable(adapter.config.ip, WATCHDOG_PROBE_PORT, WATCHDOG_PROBE_TIMEOUT_MS)
+        .then(reachable => {
+            if (!reachable) {
+                // TV is off / unreachable — defer the next probe by a full
+                // window so we don't poll the network every 30s while the TV
+                // sleeps. The lgtv2 library keeps retrying internally; the
+                // watchdog only steps in once it sees a stuck handshake.
+                lastConnectingAt = Date.now();
+                adapter.log.debug(
+                    `[WATCHDOG] TV ${adapter.config.ip}:${WATCHDOG_PROBE_PORT} not reachable — skipping recreate`,
+                );
+                return;
+            }
+            adapter.log.warn(
+                `[WATCHDOG] No reconnect attempt for ${Math.round(idleMs / 1000)}s while disconnected — recreating LGTV instance`,
+            );
+            try {
+                lgtvobj && lgtvobj.disconnect();
+            } catch (err) {
+                adapter.log.debug(`[WATCHDOG] disconnect failed: ${err}`);
+            }
+            // Suppress retrigger until the new instance has had a chance to settle.
+            lastConnectingAt = Date.now();
+            adapter.setTimeout(connect, 1000);
+        })
+        .catch(err => {
+            adapter.log.debug(`[WATCHDOG] probe failed: ${err}`);
+        })
+        .finally(() => {
+            watchdogProbeInFlight = false;
+        });
 }
 
 function checkCurApp(powerOff) {


### PR DESCRIPTION
Closes #419.

## Summary

The reconnect watchdog introduced in v2.7.0 (#415) keeps firing roughly every 90 s while the TV is simply switched off. Real log from a TV powered down for the night:

```
03:51:21 warn [WATCHDOG] No reconnect attempt for 89s while disconnected — recreating LGTV instance
03:52:51 warn [WATCHDOG] No reconnect attempt for 89s while disconnected — recreating LGTV instance
03:54:21 warn [WATCHDOG] No reconnect attempt for 89s while disconnected — recreating LGTV instance
…
```

### Root cause

`lastConnectingAt` is only updated by the `connecting` event. The `lgtv2` library emits `connecting` on the *first* attempt of each LGTV instance and then retries internally without re-emitting it. So once the watchdog enters its "recreate" loop on an offline TV, every cycle:

1. instance has not seen `connecting` for ≥ 60 s
2. watchdog warns and recreates
3. new instance fires `connecting` once → silence again
4. 60 s later: back to (1)

Result: noisy warnings all night long whenever the TV is off.

### Fix

Before triggering the recreate, run a 2 s TCP reachability probe against port 3001 (the WebSocket port the adapter is going to use anyway):

- TV unreachable → skip the recreate, log on `debug` only, defer the next probe by a full window. The `lgtv2` library keeps retrying internally; the watchdog stays quiet.
- TV reachable but adapter still disconnected → exactly the stuck-handshake case the watchdog was designed for. Log the warning, recreate the instance.

The probe is implemented as a tiny `lib/probe.js` helper (`probeTcpReachable(host, port, timeoutMs)`) so it can be unit-tested without spinning up a fake LGTV.

### Files

- `lib/probe.js` — new helper (~40 LoC)
- `lib/probe.test.js` — 4 unit tests (loopback listener, free port, TEST-NET-1 timeout, empty host)
- `main.js` — gate `checkReconnectWatchdog` recreate behind the probe, in-flight guard so a slow probe does not stack
- `eslint.config.mjs` — extend `*.test.js` ignore to `**/*.test.js` so the new test under `lib/` is excluded from production lint just like `main.test.js`
- `README.md` — changelog entry

### Test plan

- [x] `npm run lint` clean (zero warnings)
- [x] `npm run test:js` — 5 passing (4 new probe tests + existing dummy)
- [x] `npm run test:package` — 57 passing

Note: the two pre-existing `npm run check` errors (`wsconfig` typing on the `lgtv2` Config interface, deprecated `module.parent`) are present on master before this change and are out of scope here.
